### PR TITLE
Fix PHP 8.4 deprecations

### DIFF
--- a/src/EmailOctopus.php
+++ b/src/EmailOctopus.php
@@ -15,9 +15,9 @@ final class EmailOctopus
      */
     public static function client(
         string $apiKey,
-        string $baseUri = null,
-        int $timeout = null,
-        int $connectTimeout = null
+        ?string $baseUri = null,
+        ?int $timeout = null,
+        ?int $connectTimeout = null
     ): Client
     {
         return self::factory()


### PR DESCRIPTION
 PHP 8.4 added deprecations for implict nullable types. Explict nullable types were added in 7.1 so this change doesn't require an update to the minimum PHP level.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
	- Enhanced method parameter type flexibility in the `EmailOctopus` class
	- Updated method signatures to allow more lenient parameter handling
	- Improved type declarations for better method parameter compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->